### PR TITLE
Removing pinned version of the package 'six'

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,2 @@
 requests>=2.3.0
 influxdb==4.1.1
-six==1.11.0
-


### PR DESCRIPTION
The package `influxdb` already has `six` as dep, so we don't need to pin a version in the `requirements.txt`.