### PR TITLE
Fix settings key and client user and password setup

### DIFF
--- a/python_metrics_client/__init__.py
+++ b/python_metrics_client/__init__.py
@@ -13,8 +13,8 @@ def includeme(settings):
     current_app.conf.metrics_client_port = settings.registry.settings.get('metrics_client_port', 8086)
     current_app.conf.metrics_client_timeout = settings.registry.settings.get('metrics_client_timeout', 30)
     current_app.conf.metrics_client_type = settings.registry.settings.get('metrics_client_type', 'influxdb')
-    current_app.conf.metrics_user = settings.registry.settings.get('metrics_client_type', 'root')
-    current_app.conf.metrics_password = settings.registry.settings.get('metrics_client_type', 'root')
+    current_app.conf.metrics_user = settings.registry.settings.get('metrics_user', 'root')
+    current_app.conf.metrics_password = settings.registry.settings.get('metrics_password', 'root')
     current_app.conf.metrics_environment = settings.registry.settings.get('metrics_environment', 'production')
 
     logger.info('metrics-client config: server: {}://{}:{}'.format(

--- a/python_metrics_client/tasks.py
+++ b/python_metrics_client/tasks.py
@@ -51,7 +51,7 @@ def send_metric(self, metric, value, fields=None, tags=None, timestamp=None, env
         environment = self.app.conf.metrics_environment
 
     username = self.app.conf.metrics_user
-    password = self.app.conf.metrics_user
+    password = self.app.conf.metrics_password
 
     actual_send_metric(server, port, metric, value, fields=fields, tags=tags, timestamp=timestamp,
                                username=username, password=password, environment=environment, client_type=client_type)
@@ -88,7 +88,7 @@ def send_product_metric(self, product, metric, value, fields=None, tags=None,
         environment = self.app.conf.metrics_environment
 
     username = self.app.conf.metrics_user
-    password = self.app.conf.metrics_user
+    password = self.app.conf.metrics_password
 
     actual_send_product_metric(server, port, product, metric, value, fields=fields, tags=tags, timestamp=timestamp,
                                username=username, password=password, environment=environment, client_type=client_type)


### PR DESCRIPTION
- The client settings setup was using the wrong keys to setup the client `user` and `password`.
- Some tasks were using the client `user` as the `password`. This was not a problem because for now the user is the same as the password, but now that the configuration is correct it should use the right values.