### PR TITLE
Remove pinned libraries, uneeded test dependencies

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1,0 +1,101 @@
+[[package]]
+category = "main"
+description = "Python package for providing Mozilla's CA Bundle."
+name = "certifi"
+optional = false
+python-versions = "*"
+version = "2019.9.11"
+
+[[package]]
+category = "main"
+description = "Universal encoding detector for Python 2 and 3"
+name = "chardet"
+optional = false
+python-versions = "*"
+version = "3.0.4"
+
+[[package]]
+category = "main"
+description = "Internationalized Domain Names in Applications (IDNA)"
+name = "idna"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "2.8"
+
+[[package]]
+category = "main"
+description = "InfluxDB client"
+name = "influxdb"
+optional = false
+python-versions = "*"
+version = "5.2.3"
+
+[package.dependencies]
+python-dateutil = ">=2.6.0"
+pytz = "*"
+requests = ">=2.17.0"
+six = ">=1.10.0"
+
+[[package]]
+category = "main"
+description = "Extensions to the standard Python datetime module"
+name = "python-dateutil"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
+version = "2.8.0"
+
+[package.dependencies]
+six = ">=1.5"
+
+[[package]]
+category = "main"
+description = "World timezone definitions, modern and historical"
+name = "pytz"
+optional = false
+python-versions = "*"
+version = "2019.3"
+
+[[package]]
+category = "main"
+description = "Python HTTP for Humans."
+name = "requests"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "2.22.0"
+
+[package.dependencies]
+certifi = ">=2017.4.17"
+chardet = ">=3.0.2,<3.1.0"
+idna = ">=2.5,<2.9"
+urllib3 = ">=1.21.1,<1.25.0 || >1.25.0,<1.25.1 || >1.25.1,<1.26"
+
+[[package]]
+category = "main"
+description = "Python 2 and 3 compatibility utilities"
+name = "six"
+optional = false
+python-versions = ">=2.6, !=3.0.*, !=3.1.*"
+version = "1.12.0"
+
+[[package]]
+category = "main"
+description = "HTTP library with thread-safe connection pooling, file post, and more."
+name = "urllib3"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, <4"
+version = "1.25.6"
+
+[metadata]
+content-hash = "62c34f25bfed7bdadea5dd4ef01a29c6026a873472f90c9dd1bc7c2810d0999c"
+python-versions = "^3.6"
+
+[metadata.hashes]
+certifi = ["e4f3620cfea4f83eedc95b24abd9cd56f3c4b146dd0177e83a21b4eb49e21e50", "fd7c7c74727ddcf00e9acd26bba8da604ffec95bf1c2144e67aff7a8b50e6cef"]
+chardet = ["84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae", "fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"]
+idna = ["c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407", "ea8b7f6188e6fa117537c3df7da9fc686d485087abf6ac197f9c46432f7e4a3c"]
+influxdb = ["270ec1ec9cf1927a38cf5ec808e76f364482977577eb8c335f6aed5fcdc4cb25", "30276c7e04bf7659424c733b239ba2f0804d7a1f3c59ec5dd3f88c56176c8d36"]
+python-dateutil = ["7e6584c74aeed623791615e26efd690f29817a27c73085b78e4bad02493df2fb", "c89805f6f4d64db21ed966fda138f8a5ed7a4fdbc1a8ee329ce1b74e3c74da9e"]
+pytz = ["1c557d7d0e871de1f5ccd5833f60fb2550652da6be2693c1e02300743d21500d", "b02c06db6cf09c12dd25137e563b31700d3b80fcc4ad23abb7a315f2789819be"]
+requests = ["11e007a8a2aa0323f5a921e9e6a2d7e4e67d9877e85773fba9ba6419025cbeb4", "9cf5292fcd0f598c671cfc1e0d7d1a7f13bb8085e9a590f48c010551dc6c4b31"]
+six = ["3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c", "d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"]
+urllib3 = ["3de946ffbed6e6746608990594d08faac602528ac7015ac28d33cee6a45b7398", "9a107b99a5393caf59c7aa3c1249c16e6879447533d0887f4336dde834c7be86"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,16 @@
+[tool.poetry]
+name = "python-metrics-client"
+version = "0.9.14"
+description = ""
+authors = ["Developers <dev@geru.com.br>"]
+
+[tool.poetry.dependencies]
+python = "^3.6"
+influxdb = "^5.2"
+requests = "^2.22"
+
+[tool.poetry.dev-dependencies]
+
+[build-system]
+requires = ["poetry>=0.12"]
+build-backend = "poetry.masonry.api"

--- a/python_metrics_client/scripts/grafana.py
+++ b/python_metrics_client/scripts/grafana.py
@@ -20,13 +20,12 @@ def influx():
 @click.argument('tags')
 @click.argument('value')
 @click.option('-t', '--timestamp', default=None)
-def influx_send_data(url, measurement, tags, value, timestamp=None):
+def influx_send_data(url, measurement, tags, value, timestamp="0"):
 
     from python_metrics_client.influx import send_data as sd
-
     tags = json.loads(tags)
 
-    sd(url, measurement, tags, value, timestamp=timestamp)
+    sd(url, measurement, tags, value, timestamp=int(timestamp))
 
 
 @grafana.group()

--- a/python_metrics_client/tests/test_decorator.py
+++ b/python_metrics_client/tests/test_decorator.py
@@ -1,24 +1,38 @@
+from math import isclose
 
-import mock
+from unittest import mock
 import time
-from freezegun import freeze_time
 from datetime import datetime
+
 from python_metrics_client.tests.base import TestCase
 from python_metrics_client.duration import timeit
 
 
 @timeit(environment='dev')
 def decorated_function():
-    time.sleep(1)
+    time.sleep(0.2)
+
+ellapsed_time_position = 2
+timestamp_position = 4
+
+def parse_timestamp(text_ts):
+    ts = datetime.strptime(text_ts.rsplit(".", 1)[0], "%Y-%m-%dT%H:%M:%S")
+    return ts.timestamp()
 
 
 class DecoratorTest(TestCase):
 
     @mock.patch('python_metrics_client.duration._send_metric.delay')
     def test_timeit(self, requests_mock):
-        with freeze_time(datetime(2017, 10, 25, 10, 00, 00)):
             decorated_function()
-            # With freezegun, default_timer() wll always get the same time, so time elapsed will be 0.0.
-            # Time elapsed is unpredictable otherwise
-            requests_mock.assert_called_with('dev', 'duration', 0.0, [{'process_name': 'decorated_function'}],
-                                             '2017-10-25T10:00:00', None, None)
+            args = requests_mock.call_args
+            self.assertEqual(len(args), 2)
+            args = args[0]
+            expected_args =  ('dev', 'duration', 0.2, [{'process_name': 'decorated_function'}], '2017-10-25T10:00:00', None, None)
+            for step, (arg, expected_arg) in enumerate(zip(args, expected_args)):
+                if step == ellapsed_time_position:
+                    assert isclose(arg, expected_arg, abs_tol=0.001)
+                elif step == timestamp_position:
+                    assert isclose(parse_timestamp(arg), datetime.utcnow().timestamp(), abs_tol=0.5)
+                else:
+                    self.assertEqual(arg, expected_arg)

--- a/python_metrics_client/tests/test_influx.py
+++ b/python_metrics_client/tests/test_influx.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
-import mock
+from unittest import mock
+
 from python_metrics_client.tests.base import TestCase
 from influxdb import InfluxDBClient
 from datetime import datetime
@@ -18,7 +19,7 @@ class InfluxTest(TestCase):
 
         send_data('url', 'measurement', {'tag': 'value'}, 2, 1490223248024070912)
 
-        self.assertEquals(1, requests_mock.post.call_count)
+        self.assertEqual(1, requests_mock.post.call_count)
 
         requests_mock.post.assert_called_with('url', data='measurement,tag=value value=2 1490223248024070912',
                                               timeout=30)
@@ -31,7 +32,7 @@ class InfluxTest(TestCase):
 
         send_data('url', 'measurement', 'tag=value', 2, 1490223248024070912)
 
-        self.assertEquals(1, requests_mock.post.call_count)
+        self.assertEqual(1, requests_mock.post.call_count)
         requests_mock.post.assert_called_with('url', data='measurement,tag=value value=2 1490223248024070912',
                                               timeout=30)
 

--- a/python_metrics_client/tests/test_metrics_client.py
+++ b/python_metrics_client/tests/test_metrics_client.py
@@ -1,4 +1,5 @@
-import mock
+from unittest import mock
+
 from python_metrics_client.tests.base import TestCase
 from datetime import datetime
 from python_metrics_client.metrics_client import send_metric, send_product_metric

--- a/python_metrics_client/tests/test_scripts.py
+++ b/python_metrics_client/tests/test_scripts.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-import mock
+from unittest import mock
 from click.testing import CliRunner
 from python_metrics_client.tests.base import TestCase
 from python_metrics_client.scripts.grafana import influx_send_data, tasks_send_data
@@ -15,11 +15,9 @@ class ScriptsTest(TestCase):
         mocked_response.status_code = 204
 
         runner = CliRunner()
-
         response = runner.invoke(influx_send_data, ['url', 'measurement', '{"tag":"value"}', '2', '-t 1490223248024070912'])
-
-        self.assertEquals(response.exit_code, 0)
-        self.assertEquals(1, requests_mock.post.call_count)
+        self.assertEqual(response.exit_code, 0)
+        self.assertEqual(1, requests_mock.post.call_count)
         requests_mock.post.assert_called_with('url', data='measurement,tag=value value=2 1490223248024070912', timeout=30)
 
     @mock.patch('python_metrics_client.tasks.send_data')
@@ -28,6 +26,6 @@ class ScriptsTest(TestCase):
         runner = CliRunner()
         response = runner.invoke(tasks_send_data, ['measurement', '{"tag":"value"}', '2', '-t 1490223248024070912'])
 
-        self.assertEquals(response.exit_code, 0)
-        self.assertEquals(1, send_data_mock.delay.call_count)
+        self.assertEqual(response.exit_code, 0)
+        self.assertEqual(1, send_data_mock.delay.call_count)
         send_data_mock.delay.assert_called_with(u'measurement', {u'tag': u'value'}, u'2')

--- a/requirements_standalone.txt
+++ b/requirements_standalone.txt
@@ -1,5 +1,5 @@
-celery==4.0.2
-click==6.7
-ipdb==0.8
-ipython==5.1.0
-influxdb==4.1.1
+celery>=4.0.2
+click>=6.7
+ipdb>=0.8
+ipython>=5.1.0
+influxdb>=5

--- a/requirements_tests.txt
+++ b/requirements_tests.txt
@@ -1,5 +1,3 @@
 -r requirements_standalone.txt
-coverage==4.4.1
-mock==2.0.0
-nose==1.3.7
-freezegun==0.3.9
+coverage>=4.4.1
+nose>=1.3.7

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,8 @@ import os
 from setuptools import setup, find_packages
 
 requires = [
-    'requests>=2.3.0',
-    'influxdb==4.1.1',
+    'requests',
+    'influxdb',
 ]
 
 entry_points = None
@@ -16,7 +16,7 @@ if os.environ.get('STANDALONE'):
 
 
 setup(name='python_metrics_client',
-      version='0.9.13',
+      version='0.9.14',
       description='python metrics client',
       classifiers=[
           "Programming Language :: Python",


### PR DESCRIPTION
      - set minimal library versions instead of pinned versions
      - use poetry
      - drop freezegun, mock requirements
      - update test assertions

Despite the branch name, no hard-dependencies on 'python3', although I am not certain this even run in Python3 - the branch title is due to updating 'unittest.AssertEquals' to 'unittest.AssertEqual'