### PR TITLE
Executar testes com tox em múltiplas versões do python

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,16 @@
 version: 2
 jobs:
-  deploy:
+  tests:
+    docker:
+      - image: python:3.6
+    steps:
+      - checkout
+      - run:
+          name: Tests
+          command: |
+            pip install -e .[tests]
+            tox
+  release:
     docker:
       - image: python:3.6
     working_directory: ~/app
@@ -17,7 +27,10 @@ workflows:
   version: 2
   test-and-deploy:
     jobs:
-      - deploy:
+      - tests
+      - release:
+          requires:
+            - tests
           filters:
             branches:
               only:

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git
+.tox
+__pycache__
+*.pyc

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM python:3.7
+
+ENV PYTHONDONTWRITEBYTECODE 1
+
+RUN curl https://pyenv.run | bash \
+    && echo 'export PATH="/root/.pyenv/bin:$PATH"' >> /root/.bashrc \
+    && echo 'eval "$(pyenv init -)"' >> /root/.bashrc \
+    && echo 'eval "$(pyenv virtualenv-init -)"' >> /root/.bashrc
+
+ENV PATH /root/.pyenv/bin:$PATH
+RUN eval "$(pyenv init -)" \
+    && eval "$(pyenv virtualenv-init -)" \
+    && pyenv install 2.7.16 \
+    && pyenv install 3.6.9 \
+    && pyenv install 3.7.4
+
+RUN pyenv virtualenv 2.7.16 metrics-2.7 \
+    && pyenv virtualenv 3.6.9 metrics-3.6 \
+    && pyenv virtualenv 3.7.4 metrics-3.7 \
+    && pyenv global metrics-2.7 metrics-3.6 metrics-3.7
+
+RUN pip install tox==3.14.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+---
+version: '3.7'
+services:
+  client:
+    image: 'geru/metrics-client:dev'
+    build:
+      context: .
+    volumes:
+      - '.:/opt/client'
+      - 'tox_data:/opt/client/.tox'
+    working_dir: /opt/client
+    command: sleep infinity
+volumes:
+  tox_data: {}

--- a/python_metrics_client/duration.py
+++ b/python_metrics_client/duration.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
-from timeit import default_timer as timer
-from datetime import datetime
-from celery import shared_task
 import functools
+from datetime import datetime
+from timeit import default_timer as timer
 
+from celery import shared_task
 from celery.utils.log import get_task_logger
+
 from python_metrics_client.metrics_client import send_metric as actual_send_metric
 
 logger = get_task_logger(__name__)

--- a/requirements_standalone.txt
+++ b/requirements_standalone.txt
@@ -1,3 +1,0 @@
-celery==4.0.2
-click==6.7
-influxdb==5.2.3

--- a/requirements_standalone.txt
+++ b/requirements_standalone.txt
@@ -1,5 +1,3 @@
 celery==4.0.2
 click==6.7
-ipdb==0.8
-ipython==5.1.0
-influxdb==4.1.1
+influxdb==5.2.3

--- a/requirements_tests.txt
+++ b/requirements_tests.txt
@@ -1,5 +1,7 @@
 -r requirements_standalone.txt
 coverage==4.4.1
+freezegun==0.3.12
+ipdb==0.8
+ipython==5.1.0
 mock==2.0.0
 nose==1.3.7
-freezegun==0.3.9

--- a/requirements_tests.txt
+++ b/requirements_tests.txt
@@ -1,7 +1,0 @@
--r requirements_standalone.txt
-coverage==4.4.1
-freezegun==0.3.12
-ipdb==0.8
-ipython==5.1.0
-mock==2.0.0
-nose==1.3.7

--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,24 @@ from setuptools import setup, find_packages
 
 requires = [
     'requests>=2.3.0',
-    'influxdb==4.1.1',
+    'celery==4.0.2',
+    'click==6.7',
+    'influxdb==5.2.3',
 ]
+
+extras_require = {
+    'tests': [
+        'coverage==4.4.1',
+        'freezegun==0.3.12',
+        'mock==2.0.0',
+        'nose==1.3.7',
+        'tox==3.14.6',
+    ],
+}
+
+dev_ = ['ipdb==0.8', 'ipython==5.1.0']
+
+extras_require['dev'] = extras_require['tests'] + dev_
 
 entry_points = None
 if os.environ.get('STANDALONE'):
@@ -34,5 +50,6 @@ setup(
     zip_safe=False,
     test_suite='python_metrics_client',
     install_requires=requires,
+    extras_require=extras_require,
     entry_points=entry_points,
   )

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,16 @@
+[tox]
+envlist = py27, py36, py37
+# requires = -r requirements_test.txt
+
+[testenv:py27]
+basepython = python2.7
+
+[testenv:py36]
+basepython = python3.6
+
+[testenv:py37]
+basepython = python3.7
+
+[testenv]
+commands = nosetests python_metrics_client/tests
+deps = -rrequirements_tests.txt

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 envlist = py27, py36, py37
-# requires = -r requirements_test.txt
 
 [testenv:py27]
 basepython = python2.7
+commands = pip install "setuptools<45"
 
 [testenv:py36]
 basepython = python3.6
@@ -12,5 +12,6 @@ basepython = python3.6
 basepython = python3.7
 
 [testenv]
-commands = nosetests python_metrics_client/tests
-deps = -r requirements_tests.txt
+commands =
+    pip install -e .[tests]
+    nosetests

--- a/tox.ini
+++ b/tox.ini
@@ -13,4 +13,4 @@ basepython = python3.7
 
 [testenv]
 commands = nosetests python_metrics_client/tests
-deps = -rrequirements_tests.txt
+deps = -r requirements_tests.txt


### PR DESCRIPTION
Adicionado `Dockerfile` e `docker-compose.yml` que permite execução dos testes em múltiplas versões do python.