### PR TITLE
Influx db name through envvar

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,11 @@ metrics_password = root
 metrics_environment = production
 
 ```
+##### Obs:
+You can define the Influx Database name through environment variable. Export `INFLUX_DATABASE` in your environment,
+after that all the metrics will be directed to that DB (make sure the db is already created).
+
+---
 
 Functions should be called as celery tasks although it is possible to call functions directly.
 

--- a/python_metrics_client/influx.py
+++ b/python_metrics_client/influx.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import logging
+import os
 import time
 import requests
 
@@ -108,5 +109,5 @@ def send_metric(server, username, password, port, environment, metric, value, fi
     logger.info('influxdb send metric: {}'.format(data))
     logger.debug('send_metric info - server: {} port: {} username: {}'.format(server, port, username))
 
-    client = InfluxDBClient(server, int(port), username, password, 'metrics')
+    client = InfluxDBClient(server, int(port), username, password, os.environ.get('INFLUX_DATABASE', 'metrics'))
     client.write_points(data)

--- a/python_metrics_client/influx.py
+++ b/python_metrics_client/influx.py
@@ -45,7 +45,7 @@ def send_data(url, measurement, tags, value, timestamp=None, timeout=None):
     if not timestamp:
         timestamp = time.time() * 1000000000
 
-    if timestamp < time.time() * 1000000:
+    if float(timestamp) < time.time() * 1000000:
         # warn probably not send timestamp in microseconds
         logger.warn('send_data: problably not send timestamp in microseconds [{}]'.format(timestamp))
 

--- a/python_metrics_client/tests/test_decorator.py
+++ b/python_metrics_client/tests/test_decorator.py
@@ -17,8 +17,10 @@ class DecoratorTest(TestCase):
     @mock.patch('python_metrics_client.duration._send_metric.delay')
     def test_timeit(self, requests_mock):
         with freeze_time(datetime(2017, 10, 25, 10, 00, 00)):
-            decorated_function()
-            # With freezegun, default_timer() wll always get the same time, so time elapsed will be 0.0.
-            # Time elapsed is unpredictable otherwise
-            requests_mock.assert_called_with('dev', 'duration', 0.0, [{'process_name': 'decorated_function'}],
+            with mock.patch('python_metrics_client.duration.timer') as mocked_timer:
+                mocked_timer.return_value = 0.0
+                decorated_function()
+                # With freezegun, default_timer() wll always get the same time, so time elapsed will be 0.0.
+                # Time elapsed is unpredictable otherwise
+                requests_mock.assert_called_with('dev', 'duration', 0.0, [{'process_name': 'decorated_function'}],
                                              '2017-10-25T10:00:00', None, None)

--- a/python_metrics_client/tests/test_influx.py
+++ b/python_metrics_client/tests/test_influx.py
@@ -100,3 +100,42 @@ class InfluxTest(TestCase):
         send_metric_influx('localhost', 'root', 'root', 8086, 'dev', 'test', 10, timestamp=timestamp)
 
         influx_write.assert_called_with(data)
+
+    @mock.patch.dict('python_metrics_client.influx.os.environ', {})
+    @mock.patch('python_metrics_client.influx.InfluxDBClient')
+    def test_send_metric_with_no_envvar(self, client_mock):
+        timestamp = datetime(2017, 10, 19, 18, 12, 51)
+        fields = [
+            {'value': 10},
+            {'add_field_1': 'a'},
+            {'add_field_2': 2},
+        ]
+        tags = [
+            {'environment': 'dev'},
+            {'product': 'consignado'},
+        ]
+
+        send_metric_influx('localhost', 'root', 'root', 8086, 'dev', 'test', value=1, fields=fields, tags=tags, timestamp=timestamp)
+
+        client_mock.assert_called_with('localhost', 8086, 'root', 'root', 'metrics')
+
+    @mock.patch.dict('python_metrics_client.influx.os.environ', {'INFLUX_DATABASE': 'test-metrics'})
+    @mock.patch('python_metrics_client.influx.InfluxDBClient')
+    def test_send_metric_with_envvar(self, client_mock):
+        timestamp = datetime(2017, 10, 19, 18, 12, 51)
+
+        fields = [
+            {'value': 10},
+            {'add_field_1': 'a'},
+            {'add_field_2': 2},
+        ]
+
+        tags = [
+            {'environment': 'dev'},
+            {'product': 'consignado'},
+        ]
+
+        send_metric_influx('localhost', 'root', 'root', 8086, 'dev', 'test', value=1, fields=fields, tags=tags,
+                           timestamp=timestamp)
+
+        client_mock.assert_called_with('localhost', 8086, 'root', 'root', 'test-metrics')

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ if os.environ.get('STANDALONE'):
 
 
 setup(name='python_metrics_client',
-      version='0.9.13',
+      version='0.9.14',
       description='python metrics client',
       classifiers=[
           "Programming Language :: Python",


### PR DESCRIPTION
Decidimos utilizar a configuração do nome do database via environment variable por ser mais simples, e por ser o que precisamos no momento para a aplicação que usa essa lib como dependencia. 