### PR TITLE
Fix string verification compatibility.

### DIFF
--- a/python_metrics_client/influx.py
+++ b/python_metrics_client/influx.py
@@ -2,6 +2,7 @@
 import logging
 import os
 import time
+import six
 from datetime import datetime
 
 import requests
@@ -30,7 +31,7 @@ def _convert_timestamp(timestamp):
 
     if isinstance(timestamp, datetime):
         return timestamp.strftime('%Y-%m-%dT%H:%M:%S.%fZ')
-    elif isinstance(timestamp, (str, unicode)):
+    elif isinstance(timestamp, six.string_types):
         return timestamp
     else:
         logger.info('%s is not a valid timestamp type', type(timestamp))

--- a/python_metrics_client/tests/test_influx.py
+++ b/python_metrics_client/tests/test_influx.py
@@ -54,9 +54,65 @@ class InfluxTest(TestCase):
         self.assertRaises(BadRequest, send_data, 'url', 'measurement', 'tag=value', 2, 1490223248024070912)
 
     @mock.patch.object(InfluxDBClient, 'write_points')
-    def test_send_metric_with_time(self, influx_write):
+    def test_send_metric_with_time_as_datetime(self, influx_write):
 
         timestamp = datetime(2017, 10, 19, 18, 12, 51)
+        data = [
+                    {
+                        'fields': {
+                            'value': 10,
+                            'add_field_1': 'a',
+                            'add_field_2': 2
+                        },
+                        'time': '2017-10-19T18:12:51.000000Z',
+                        'tags': {
+                            'environment': 'dev',
+                            'product': 'consignado'
+                        },
+                        'measurement': 'test'
+                    }
+                ]
+
+        send_metric_influx(
+            'localhost', 'root', 'root',  8086, 'dev', 'test', 10,
+            fields=[{'add_field_1': 'a'}, {'add_field_2': 2}], tags=[{'product': 'consignado'}], timestamp=timestamp
+        )
+
+        influx_write.assert_called_with(data)
+
+    @mock.patch.object(InfluxDBClient, 'write_points')
+    def test_send_metric_with_time_as_string(self, influx_write):
+
+        timestamp = datetime(2017, 10, 19, 18, 12, 51).strftime('%Y-%m-%dT%H:%M:%S.%fZ')
+        timestamp = '{}'.format(timestamp)
+        data = [
+                    {
+                        'fields': {
+                            'value': 10,
+                            'add_field_1': 'a',
+                            'add_field_2': 2
+                        },
+                        'time': '2017-10-19T18:12:51.000000Z',
+                        'tags': {
+                            'environment': 'dev',
+                            'product': 'consignado'
+                        },
+                        'measurement': 'test'
+                    }
+                ]
+
+        send_metric_influx(
+            'localhost', 'root', 'root',  8086, 'dev', 'test', 10,
+            fields=[{'add_field_1': 'a'}, {'add_field_2': 2}], tags=[{'product': 'consignado'}], timestamp=timestamp
+        )
+
+        influx_write.assert_called_with(data)
+
+    @mock.patch.object(InfluxDBClient, 'write_points')
+    def test_send_metric_with_time_as_unicode(self, influx_write):
+
+        timestamp = datetime(2017, 10, 19, 18, 12, 51).strftime('%Y-%m-%dT%H:%M:%S.%fZ')
+        timestamp = u'{}'.format(timestamp)
         data = [
                     {
                         'fields': {


### PR DESCRIPTION
Problemas com python 3

```Traceback (most recent call last):
  File "/home/geru/Geru/python-metrics-client/.tox/py36/lib/python3.6/site-packages/mock/mock.py", line 1305, in patched
    return func(*args, **keywargs)
  File "/home/geru/Geru/python-metrics-client/python_metrics_client/tests/test_influx.py", line 134, in test_send_metric_with_time_as_unicode
    fields=[{'add_field_1': 'a'}, {'add_field_2': 2}], tags=[{'product': 'consignado'}], timestamp=timestamp
  File "/home/geru/Geru/python-metrics-client/python_metrics_client/influx.py", line 109, in send_metric
    str_timestamp = _convert_timestamp(timestamp)
  File "/home/geru/Geru/python-metrics-client/python_metrics_client/influx.py", line 33, in _convert_timestamp
    elif isinstance(timestamp, (str, unicode)):
NameError: name 'unicode' is not defined
```